### PR TITLE
Reuse apklibs resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <groupId>com.jayway.maven.plugins.android.generation2</groupId>
     <artifactId>android-maven-plugin</artifactId>
-    <version>3.7.0</version>
+    <version>3.7.0-tuenti2</version>
     <packaging>maven-plugin</packaging>
     <name>Android Maven Plugin - android-maven-plugin</name>
     <description>Maven Plugin for Android Development</description>

--- a/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
+++ b/src/main/java/com/jayway/maven/plugins/android/phase01generatesources/GenerateSourcesMojo.java
@@ -699,27 +699,23 @@ public class GenerateSourcesMojo extends AbstractAndroidMojo
             return true;
         }
 
+        if ( classFileRFor( apklibArtifact ).exists() )
+        {
+            getLog().info( "R found at " + classFileForR + ", so it won't be regenerated" );
+            return false;
+        }
+
+        return true;
+    }
+
+    private File classFileRFor( Artifact apklibArtifact )
+    {
         final String libraryUnpackDirectory = getLibraryUnpackDirectory( apklibArtifact );
-        boolean shouldGenerateR = true;
-        try
-        {
-            String libPackage  = extractPackageNameFromAndroidManifest( new File( libraryUnpackDirectory +
-                    File.separator + "AndroidManifest.xml" ) );
+        String libPackage  = extractPackageNameFromAndroidManifest( new File( libraryUnpackDirectory +
+                File.separator + "AndroidManifest.xml" ) );
 
-            File classFileForR = new File( project.getBuild().getOutputDirectory() + File.separator
-                    + libPackage.replace( ".", File.separator ) + File.separator + "R.class" );
-            if ( classFileForR.exists() )
-            {
-                getLog().info( "R found at " + classFileForR + ", so it won't be regenerated" );
-                shouldGenerateR = false;
-            }
-        }
-        catch ( MojoExecutionException e )
-        {
-            // do nothing, will return default value
-        }
-
-        return shouldGenerateR;
+        return new File( project.getBuild().getOutputDirectory() + File.separator
+                + libPackage.replace( ".", File.separator ) + File.separator + "R.class" );
     }
 
     private void generateRForApkLibDependency( Artifact apklibArtifact ) throws MojoExecutionException


### PR DESCRIPTION
Enable the possibility of skipping the processing of apklibs if they are already generated from a previous build. This is useful for speeding up the execution of tests, for instance.

An additional boolean parameter is provided that keeps current behavior by default. 
